### PR TITLE
Add a results page before the final page

### DIFF
--- a/app/views/facilitiesManagement/procurements/show.html
+++ b/app/views/facilitiesManagement/procurements/show.html
@@ -34,10 +34,11 @@
         <div class="govuk-!-margin-top-5">
           {{ govukButton({
             element: "input",
-            text: "Save and continue",
+            text: "Continue",
             name: "afterSave",
             classes: "govuk-!-margin-right-4"
           }) if pageDescription.saveAndContinue }}
+          {{ govukButton(pageDescription.secondaryButton) if pageDescription.secondaryButton }}
           <br/>
           <a href="/facilities-management/RM6232" class="govuk-body govuk-link--no-visited-state">
             Return to your account
@@ -46,5 +47,4 @@
       </div>
     </div>
   </form>
-    
 {% endblock %}

--- a/app/views/facilitiesManagement/procurements/showSteps/_results.html
+++ b/app/views/facilitiesManagement/procurements/showSteps/_results.html
@@ -1,0 +1,63 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Results</h1>
+    <p class="govuk-body-l">
+      Based on information provided, this procurement is eligible for the following sub-lot:
+    </p>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">
+      Sub-lot {{ pageDescription.additionalDetails.lotNumber }}
+    </h2>
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-0">
+      {{ pageDescription.additionalDetails.selectedSuppliersNames.length }} supplier(s) shortlisted
+    </h3>
+    <p class="govuk-body govuk-!-font-weight-bold">
+      who can provide the services you require in your location(s)
+    </p>
+    <ul class="govuk-list">
+      {% for supplierName in pageDescription.additionalDetails.selectedSuppliersNames %}
+        <li class="govuk-!-width-one-half">
+          {{ supplierName }}
+          {% if not loop.last  %}
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-width-two-thirds govuk-!-margin-top-0">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading govuk-heading-m">
+      Buildings and services summary
+    </h3>
+    <div class="govuk-!-margin-bottom-4">
+      {{ govukDetails({
+        summaryText: pageDescription.additionalDetails.buildings.text,
+        html: pageDescription.additionalDetails.buildings.list
+      }) }}
+    </div>
+    <div>
+      {{ govukDetails({
+        summaryText: pageDescription.additionalDetails.services.text,
+        html: pageDescription.additionalDetails.services.list
+      }) }}
+    </div>
+  </div>
+</div>
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-width-two-thirds govuk-!-margin-top-0">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {{ govukWarningText({
+      text: "You will not be able to change your requirements for this procurement once you click 'Continue'",
+      iconFallbackText: "Warning"
+    }) }}
+    <p>
+      If you wish to change your requirements, click the 'Change requirements' button below. Any changes may result in a different outcome.
+    </p>
+  </div>
+</div>

--- a/src/app/data/active/procurementBuildings.ts
+++ b/src/app/data/active/procurementBuildings.ts
@@ -28,14 +28,14 @@ const procurementBuildings: Array<ProcurementBuildingRow> = [
     procurementID: '000004',
     buildingID: '000004',
     active: true,
-    serviceCodes: ['E.1', 'E.2', 'F.1']
+    serviceCodes: ['E.1', 'E.2', 'F.1', 'F.2']
   },
   {
     id: '000005',
     procurementID: '000004',
     buildingID: '000005',
     active: true,
-    serviceCodes: ['F.2', 'G.1', 'G.2']
+    serviceCodes: ['F.1', 'F.2', 'G.1', 'G.2']
   }
 ]
 

--- a/src/app/data/active/procurements.ts
+++ b/src/app/data/active/procurements.ts
@@ -69,7 +69,7 @@ const procurements: Array<ProcurementRow> = [
     mobilisationPeriodRequired: false,
     optionalCallOffRequired: false,
     procurementBuildingIDs: ['000004', '000005'],
-    state: 'entering_requirements',
+    state: 'results',
     updatedAt: '2022-07-01T15:33:00'
   },
   {

--- a/src/app/routes/facilitiesManagement/procurements.ts
+++ b/src/app/routes/facilitiesManagement/procurements.ts
@@ -70,7 +70,12 @@ router.post('/:id', (req: Request, res: Response) => {
   const state: string = procurement.data.state as string
 
   if (procurement.validate(state)) {
-    procurement.goToNextState()
+    if (req.body['changeRequirements'] !== undefined) {
+      procurement.goToPreviousState()
+    } else {
+      procurement.goToNextState()
+    }
+
     procurement.save()
 
     res.redirect(`/facilities-management/RM6232/procurements/${procurement.data.id}`)

--- a/src/app/types/models/active/facilitiesManagement/procurement.ts
+++ b/src/app/types/models/active/facilitiesManagement/procurement.ts
@@ -1,6 +1,7 @@
 import ProcurementBuilding from '../../../../models/active/facilitiesManagement/procurementBuildings/model'
 import SecondaryRegion from '../../../../models/static/facilitiesManagement/secondaryRegion/model'
 import Service from '../../../../models/static/facilitiesManagement/service/model'
+import SuppliersSelector from '../../../../services/suppliersSelector'
 import { ValidatorOptions } from 'ccs-prototype-kit-model-interface'
 
 export interface ProcurementInterface {
@@ -8,6 +9,7 @@ export interface ProcurementInterface {
   services: () => Service[]
   regions: () => SecondaryRegion[]
   goToNextState: () => void
+  goToPreviousState: () => void
   initialCallOffPeriod: () => number
   initialCallOffPeriodStartDate: () => Date
   initialCallOffPeriodEndDate: () => Date
@@ -23,6 +25,8 @@ export interface ProcurementInterface {
   activeProcurementBuildings: () => Array<ProcurementBuilding>
   findOrBuildProcurementBuildings: (data: {[key: string]: any}) => void
   status: (section: string) => string
+  suppliersSelector: () => SuppliersSelector
+  uniqueServiceNames: () => string[]
 }
 
 export type ProcurementData = {

--- a/src/app/types/utils/pageSetup/procurementSetup.ts
+++ b/src/app/types/utils/pageSetup/procurementSetup.ts
@@ -14,7 +14,15 @@ export type ProcurementAdvancedRowItems = [
 export type ProcurementShowPageDescription = {
   pageTitle: string
   saveAndContinue: boolean
+  secondaryButton?: GovUKButton
   additionalDetails?: {[key: string]: any}
+}
+
+type GovUKButton = {
+  element: string
+  text: string
+  name: string
+  classes?: string
 }
 
 export type ProcurementEditPageDescription = {


### PR DESCRIPTION
- Select the suppliers on the results page
- Show the buildings and services
- Add the secondary button
- Can go back to the previous state on the results page