### PR TITLE
Update the version of ts-ccs-frontend to the latest release and make use of its new features

### DIFF
--- a/app/views/application.html
+++ b/app/views/application.html
@@ -45,10 +45,14 @@
     homepageUrl: "/",
     serviceName: serviceName,
     serviceUrl: "/facilities-management/RM6232",
-    navigationPrimary: [
+    serviceAuthentication: [
       {
-        text: "My Account",
+        text: "My account",
         href: "/facilities-management/RM6232"
+      },
+      {
+        text: "Sign out",
+        href: "#"
       }
     ]
   }) }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "portscanner": "^2.1.1",
         "require-dir": "^1.0.0",
         "sync-request": "^6.0.0",
-        "ts-ccs-frontend": "^0.5.1",
+        "ts-ccs-frontend": "^0.6.1",
         "universal-analytics": "^0.4.16",
         "uuid": "^8.3.2"
       },
@@ -15440,9 +15440,9 @@
       }
     },
     "node_modules/ts-ccs-frontend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ts-ccs-frontend/-/ts-ccs-frontend-0.5.1.tgz",
-      "integrity": "sha512-XF32bX7OkVUuONC8JazeHV3ud9OdHOFxRsd8wUolFZMk5OOPs5HdiJb9oKa07bccZ7sxCbfUImUgapFnqsjEmA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/ts-ccs-frontend/-/ts-ccs-frontend-0.6.1.tgz",
+      "integrity": "sha512-bZeEHHFwojSiPN8DEChTpLiU0aNPx/sjCiUSbJhvMUpWFZdDs18hxa0jz9NDVLOQ9lDyt6miPgrHAscSyzioxg==",
       "dependencies": {
         "govuk-frontend": "^4.0.0"
       },
@@ -28337,9 +28337,9 @@
       }
     },
     "ts-ccs-frontend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ts-ccs-frontend/-/ts-ccs-frontend-0.5.1.tgz",
-      "integrity": "sha512-XF32bX7OkVUuONC8JazeHV3ud9OdHOFxRsd8wUolFZMk5OOPs5HdiJb9oKa07bccZ7sxCbfUImUgapFnqsjEmA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/ts-ccs-frontend/-/ts-ccs-frontend-0.6.1.tgz",
+      "integrity": "sha512-bZeEHHFwojSiPN8DEChTpLiU0aNPx/sjCiUSbJhvMUpWFZdDs18hxa0jz9NDVLOQ9lDyt6miPgrHAscSyzioxg==",
       "requires": {
         "govuk-frontend": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "portscanner": "^2.1.1",
     "require-dir": "^1.0.0",
     "sync-request": "^6.0.0",
-    "ts-ccs-frontend": "^0.5.1",
+    "ts-ccs-frontend": "^0.6.1",
     "universal-analytics": "^0.4.16",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
Update the version of ts-ccs-frontend to the latest release (v0.6.1)
Add the authentication section to the header which was a feature added in the latest release of ts-ccs-frontend

This is what it looks like now:
<img width="1038" alt="Screenshot 2022-04-29 at 10 29 05" src="https://user-images.githubusercontent.com/58297459/165919336-95bc6791-773b-4d2c-b846-c4e86d839954.png">
